### PR TITLE
fix: add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Thursdays, 4:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This PR adds the "GitHub Skills" activity to the activities list, making it available for student registration as requested in Issue #6. 

- Activity name: GitHub Skills
- Description: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.
- Schedule: Thursdays, 4:30 PM - 5:30 PM
- Max participants: 25

Closes #6.